### PR TITLE
feat: `serve` command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,11 @@ md-fetch --browser curl --save --filename output.md https://www.google.com
 
 Start the HTTP server:
 ```bash
-md-fetch --serve [-port 8080]
+md-fetch serve [flags]
+
+Flags:
+  -h, --help        help for serve
+  -p, --port int    Port for HTTP server (default 8080)
 ```
 
 The server provides a REST API for fetching content:

--- a/README.md
+++ b/README.md
@@ -86,12 +86,18 @@ go install github.com/nathabonfim59/md-fetch@latest
 
 Basic usage:
 ```bash
-md-fetch <url>
+md-fetch [url]
 ```
 
-With browser selection:
+Options:
 ```bash
-md-fetch -browser <chrome|firefox|curl> <url>
+md-fetch [flags] [url]
+
+Flags:
+  -b, --browser string    Browser to use (optional, defaults to chrome > firefox > curl)
+  -f, --filename string   Custom filename to save the content (optional, defaults to slugified URL)
+  -h, --help             help for md-fetch
+  -s, --save             Save content to a file with slugified URL name
 ```
 
 Examples:
@@ -100,13 +106,13 @@ Examples:
 md-fetch https://www.google.com
 
 # Use Chrome specifically
-md-fetch -browser chrome https://www.google.com
+md-fetch --browser chrome https://www.google.com
 
-# Use Firefox specifically
-md-fetch -browser firefox https://www.google.com
+# Use Firefox and save to file
+md-fetch --browser firefox --save https://www.google.com
 
-# Use curl for static content
-md-fetch -browser curl https://www.google.com
+# Use curl and specify custom filename
+md-fetch --browser curl --save --filename output.md https://www.google.com
 ```
 
 ### Server Mode

--- a/cmd/fetch/main.go
+++ b/cmd/fetch/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gosimple/slug"
 	"github.com/nathabonfim59/md-fetch/internal/browser"
 	"github.com/nathabonfim59/md-fetch/internal/fetcher"
+	"github.com/nathabonfim59/md-fetch/internal/server"
 	"github.com/spf13/cobra"
 )
 
@@ -15,6 +16,7 @@ var (
 	browserType string
 	save        bool
 	filename    string
+	port        int
 )
 
 var rootCmd = &cobra.Command{
@@ -54,10 +56,29 @@ Supports multiple browsers and can bypass anti-scraping measures.`,
 	},
 }
 
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Start HTTP server mode",
+	Long: `Start md-fetch in HTTP server mode. This provides a REST API for fetching content
+from multiple URLs in parallel.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		srv := server.New(port)
+		if err := srv.Start(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error starting server: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
 func init() {
+	// Root command flags
 	rootCmd.Flags().StringVarP(&browserType, "browser", "b", "", fmt.Sprintf("Browser to use (optional, defaults to %s)", strings.Join(browser.DefaultBrowsers, " > ")))
 	rootCmd.Flags().BoolVarP(&save, "save", "s", false, "Save content to a file with slugified URL name")
 	rootCmd.Flags().StringVarP(&filename, "filename", "f", "", "Custom filename to save the content (optional, defaults to slugified URL)")
+
+	// Server command flags
+	serveCmd.Flags().IntVarP(&port, "port", "p", 8080, "Port for HTTP server")
+	rootCmd.AddCommand(serveCmd)
 }
 
 func main() {


### PR DESCRIPTION
This pull request introduces several enhancements to the `md-fetch` tool, including new command-line options, improved documentation, and the addition of an HTTP server mode. The most important changes are detailed below:

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L89-R100): Updated the basic usage section to include new flags and options, and revised the examples to demonstrate the use of these new options. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L89-R100) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R126)

### New Features:

* [`cmd/fetch/main.go`](diffhunk://#diff-e7d371c7ca945325321a603f9f76f2b20fdc3b79bd93a7890eae8f28985ed1f7R11-R19): Added a new `serve` command to start the tool in HTTP server mode, providing a REST API for fetching content. This includes the necessary imports and command definitions. [[1]](diffhunk://#diff-e7d371c7ca945325321a603f9f76f2b20fdc3b79bd93a7890eae8f28985ed1f7R11-R19) [[2]](diffhunk://#diff-e7d371c7ca945325321a603f9f76f2b20fdc3b79bd93a7890eae8f28985ed1f7R59-R81)