### PR TITLE
build: replace manual build with goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bin/
 *.deb
 *.rpm
+# Added by goreleaser init:
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,137 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
+builds:
+  - id: default
+    main: ./cmd/fetch
+    binary: md-fetch
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+    flags:
+      - -trimpath
+  
+  - id: musl
+    main: ./cmd/fetch
+    binary: md-fetch
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-linux-musl-gcc
+    goos:
+      - linux
+    goarch:
+      - amd64
+    ldflags:
+      - -s -w
+      - -linkmode external
+      - -extldflags "-static"
+    flags:
+      - -trimpath
+    hooks:
+      post:
+        - upx "{{ .Path }}"
+
+upx:
+  - enabled: true
+    goos: [linux, windows]
+    goarch: [amd64, "386"]
+    compress: best
+
+nfpms:
+  - id: packages-musl
+    builds: [musl]
+    package_name: md-fetch
+    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}_musl"
+    vendor: nathabonfim59
+    homepage: https://github.com/nathabonfim59/md-fetch
+    maintainer: Nathanael Bonfim <nathanael@bonfim.dev>
+    description: A powerful command-line tool that fetches web content and converts it to clean, readable Markdown format.
+    license: MIT
+    formats:
+      - deb
+      - rpm
+    dependencies:
+      - git
+    recommends:
+      - google-chrome
+      - firefox
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/md-fetch/LICENSE
+      - src: README.md
+        dst: /usr/share/doc/md-fetch/README.md
+    meta: false
+    bindir: /usr/bin
+
+archives:
+  - id: default
+    builds: [default]
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    files:
+      - LICENSE
+      - README.md
+  
+  - id: musl
+    builds: [musl]
+    formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}_musl
+    files:
+      - LICENSE
+      - README.md
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: nathabonfim59
+    name: md-fetch
+  draft: true
+  prerelease: auto
+  mode: replace
+  footer: |
+    ---
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser)
+    
+    **Full Changelog**: https://github.com/nathabonfim59/md-fetch/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
-.PHONY: build test clean install lint snapshot release
+.PHONY: build test clean install lint snapshot release release-major release-minor release-patch
 
 BINARY_NAME=md-fetch
 BUILD_DIR=bin
 GO_FILES=$(shell find . -name '*.go')
+
+# Get the latest tag without the 'v' prefix
+CURRENT_VERSION=$(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
+# Split version into major, minor, and patch
+MAJOR=$(shell echo $(CURRENT_VERSION) | cut -d. -f1)
+MINOR=$(shell echo $(CURRENT_VERSION) | cut -d. -f2)
+PATCH=$(shell echo $(CURRENT_VERSION) | cut -d. -f3)
 
 build:
 	goreleaser build --clean --single-target --snapshot
@@ -13,8 +20,39 @@ build-all:
 snapshot:
 	goreleaser release --clean --snapshot
 
+release-major:
+	@echo "Current version: v$(CURRENT_VERSION)"
+	$(eval NEW_VERSION=$(shell echo $$(($(MAJOR)+1)).0.0))
+	@echo "Creating major release v$(NEW_VERSION)"
+	@read -p "Press enter to continue..." \
+	&& git tag -a v$(NEW_VERSION) -m "Release v$(NEW_VERSION)" \
+	&& git push origin v$(NEW_VERSION) \
+	&& goreleaser release --clean
+
+release-minor:
+	@echo "Current version: v$(CURRENT_VERSION)"
+	$(eval NEW_VERSION=$(shell echo $(MAJOR).$$(($(MINOR)+1)).0))
+	@echo "Creating minor release v$(NEW_VERSION)"
+	@read -p "Press enter to continue..." \
+	&& git tag -a v$(NEW_VERSION) -m "Release v$(NEW_VERSION)" \
+	&& git push origin v$(NEW_VERSION) \
+	&& goreleaser release --clean
+
+release-patch:
+	@echo "Current version: v$(CURRENT_VERSION)"
+	$(eval NEW_VERSION=$(shell echo $(MAJOR).$(MINOR).$$(($(PATCH)+1))))
+	@echo "Creating patch release v$(NEW_VERSION)"
+	@read -p "Press enter to continue..." \
+	&& git tag -a v$(NEW_VERSION) -m "Release v$(NEW_VERSION)" \
+	&& git push origin v$(NEW_VERSION) \
+	&& goreleaser release --clean
+
 release:
-	goreleaser release --clean
+	@echo "Please use one of:"
+	@echo "  make release-major  - for major version updates (X.0.0)"
+	@echo "  make release-minor  - for minor version updates (x.Y.0)"
+	@echo "  make release-patch  - for patch version updates (x.y.Z)"
+	@echo "This ensures proper version management and tag creation."
 
 test:
 	go test ./...

--- a/Makefile
+++ b/Makefile
@@ -69,5 +69,8 @@ lint:
 	go fmt ./...
 	go vet ./...
 
-run: build
-	./dist/md-fetch_*/md-fetch
+%:
+	@:
+
+run:
+	go run cmd/fetch/main.go $(filter-out $@,$(MAKECMDGOALS))


### PR DESCRIPTION
This pull request introduces significant changes to the build and release process for the project. The main updates include the addition of a new GoReleaser configuration file, modifications to the `Makefile` to streamline the build and release commands, and updates to the `lint` target.

Build and release process improvements:

* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R1-R137): Added a new GoReleaser configuration file to automate the build and release process, including hooks, build configurations, packaging, and release settings.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R62): Updated the `Makefile` to use GoReleaser for building and releasing, replacing the previous manual build commands with new targets for snapshot and release versions.

Linting and running improvements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L73-R73): Updated the `run` target to use the new output directory structure created by GoReleaser.
This pull request includes significant changes to the build and release process for the project. The most important changes involve the introduction of `goreleaser` for managing builds and releases, modifications to the `Makefile` to support the new process, and the addition of a new configuration file.

Build and release process improvements:

* Added a new `.goreleaser.yaml` configuration file to define the build and release process, including hooks, builds, archives, and release settings. This file supports multiple operating systems and architectures and includes specific settings for musl builds.
* Updated the `Makefile` to replace manual build commands with `goreleaser` commands. This includes new targets for `snapshot`, `release`, `release-major`, `release-minor`, and `release-patch`, which automate the versioning and tagging process.
* Simplified the `run` target in the `Makefile` to use `go run` directly, allowing for easier execution of the main program.